### PR TITLE
Optimize particle system performance

### DIFF
--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,0 +1,98 @@
+import List from '../src/lib/util/List'
+import Color from '../src/lib/util/Color'
+
+function benchEmitterUpdateParticles() {
+  const list = new List()
+  for (let i = 0; i < 1000; i++) {
+    list.add({})
+  }
+
+  const oldStyle = () => {
+    list.forEach(() => {})
+  }
+  const newStyle = () => {
+    let current = list.first
+    while (current) {
+      current = current.next
+    }
+  }
+
+  const iterations = 10000
+  let start = Date.now()
+  for (let i = 0; i < iterations; i++) oldStyle()
+  const oldTime = Date.now() - start
+
+  start = Date.now()
+  for (let i = 0; i < iterations; i++) newStyle()
+  const newTime = Date.now() - start
+
+  console.log('updateParticles old vs new (ms):', oldTime, newTime)
+}
+
+function benchAmplitude() {
+  const data = new Uint8Array(1024)
+  for (let i = 0; i < data.length; i++) data[i] = Math.floor(Math.random() * 256)
+
+  const oldReduce = () => {
+    return data.reduce((a, b) => a + b, 0) / data.length
+  }
+  const newLoop = () => {
+    let sum = 0
+    for (let i = 0; i < data.length; i++) sum += data[i]
+    return sum / data.length
+  }
+
+  const iterations = 10000
+  let start = Date.now()
+  for (let i = 0; i < iterations; i++) oldReduce()
+  const oldTime = Date.now() - start
+
+  start = Date.now()
+  for (let i = 0; i < iterations; i++) newLoop()
+  const newTime = Date.now() - start
+
+  console.log('getAmplitude old vs new (ms):', oldTime, newTime)
+}
+
+class OldColor {
+  r: number
+  g: number
+  b: number
+  alpha: number
+  constructor(r = 0, g = 0, b = 0, a = 1) {
+    this.r = r
+    this.g = g
+    this.b = b
+    this.alpha = a
+  }
+  get hex() {
+    let hex = this.r << 16
+    hex = hex | (this.g << 8)
+    hex = hex | this.b
+    return hex
+  }
+  set hex(value: number) {
+    this.r = (value & 0xff0000) >> 16
+    this.g = (value & 0xff00) >> 8
+    this.b = value & 0xff
+  }
+}
+
+function benchColorHex() {
+  const oldColor = new OldColor(10, 20, 30, 1)
+  const newColor = new Color(10, 20, 30, 1)
+  const loops = 100000
+  let sum = 0
+  let start = Date.now()
+  for (let i = 0; i < loops; i++) sum += oldColor.hex
+  const oldTime = Date.now() - start
+  sum = 0
+  start = Date.now()
+  for (let i = 0; i < loops; i++) sum += newColor.hex
+  const newTime = Date.now() - start
+  console.log('Color hex old vs new (ms):', oldTime, newTime)
+}
+
+benchEmitterUpdateParticles()
+benchAmplitude()
+benchColorHex()

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "build": "npm run clean-dist && tsc",
     "clean-dist": "rimraf dist/*",
     "lint": "tslint 'src/**/*.ts'",
-    "lint:fix": "tslint --fix 'src/**/*.ts'"
+    "lint:fix": "tslint --fix 'src/**/*.ts'",
+    "benchmark": "ts-node benchmark/index.ts"
   },
   "version": "4.18.0"
 }

--- a/src/lib/behaviour/EmitterBehaviours.ts
+++ b/src/lib/behaviour/EmitterBehaviours.ts
@@ -111,8 +111,8 @@ export default class EmitterBehaviours {
    * @param {Model} model The model
    */
   apply = (particle: Particle, deltaTime: number, model: Model) => {
+    model.updateCamera(deltaTime)
     for (let i = 0; i < this.behaviours.length; ++i) {
-      model.updateCamera(deltaTime)
       this.behaviours[i].apply(particle, deltaTime, model)
     }
   }

--- a/src/lib/behaviour/ForceFieldsBehaviour.ts
+++ b/src/lib/behaviour/ForceFieldsBehaviour.ts
@@ -16,6 +16,7 @@ export default class ForceFieldsBehaviour extends Behaviour {
   fields: {
     position: Point
     radius: number
+    radiusSquared?: number
     strength: number
     type: 'wind' | 'gravity' | 'turbulence'
     direction?: Point // For wind
@@ -38,10 +39,15 @@ export default class ForceFieldsBehaviour extends Behaviour {
     if (!this.enabled || particle.skipPositionBehaviour) return
 
     this.fields.forEach((field) => {
-      const distance = Math.sqrt((particle.x - field.position.x) ** 2 + (particle.y - field.position.y) ** 2)
+      if (!field.radiusSquared) {
+        field.radiusSquared = field.radius * field.radius
+      }
+      const dx = particle.x - field.position.x
+      const dy = particle.y - field.position.y
+      const distSq = dx * dx + dy * dy
 
-      // Check if the particle is within the field's radius
-      if (distance <= field.radius) {
+      if (distSq <= field.radiusSquared) {
+        const distance = Math.sqrt(distSq)
         const influence = (field.radius - distance) / field.radius // Influence factor (closer = stronger)
 
         switch (field.type) {
@@ -53,9 +59,9 @@ export default class ForceFieldsBehaviour extends Behaviour {
             break
 
           case 'gravity':
-            const dx = field.position.x - particle.x
-            const dy = field.position.y - particle.y
-            const angle = Math.atan2(dy, dx)
+            const dxg = field.position.x - particle.x
+            const dyg = field.position.y - particle.y
+            const angle = Math.atan2(dyg, dxg)
             particle.movement.x += Math.cos(angle) * field.strength * influence * deltaTime
             particle.movement.y += Math.sin(angle) * field.strength * influence * deltaTime
             break

--- a/src/lib/behaviour/SoundReactiveBehaviour.ts
+++ b/src/lib/behaviour/SoundReactiveBehaviour.ts
@@ -76,7 +76,10 @@ export default class SoundReactiveBehaviour extends Behaviour {
   getAmplitude(): number {
     if (!this.frequencyData) return 0
 
-    const sum = this.frequencyData.reduce((a, b) => a + b, 0)
+    let sum = 0
+    for (let i = 0; i < this.frequencyData.length; i++) {
+      sum += this.frequencyData[i]
+    }
     return sum / this.frequencyData.length
   }
 

--- a/src/lib/emitter/Emitter.ts
+++ b/src/lib/emitter/Emitter.ts
@@ -43,7 +43,7 @@ export default class Emitter extends eventemitter3 {
    * Triggers the COMPLETE event when the duration is elapsed and the list is empty.
    * @param {number} deltaTime - Time elapsed since the last update
    */
-  async update(deltaTime: number) {
+  update(deltaTime: number) {
     if (!this._play) return
 
     this.behaviours.update(deltaTime)
@@ -88,9 +88,12 @@ export default class Emitter extends eventemitter3 {
    * @param {number} deltaTime - The amount of time that has passed since the last update
    */
   updateParticles(deltaTime: number) {
-    this.list.forEach((particle: Particle) => {
-      this.updateParticle(particle, deltaTime)
-    })
+    let current = this.list.first as Particle | null
+    while (current) {
+      const next = current.next as Particle | null
+      this.updateParticle(current, deltaTime)
+      current = next
+    }
   }
 
   /**

--- a/src/lib/pixi/Renderer.ts
+++ b/src/lib/pixi/Renderer.ts
@@ -33,6 +33,7 @@ export default class Renderer extends ParticleContainer {
   private _model: Model = new Model()
   private _ticker: Ticker | undefined
   private _visibilitychangeBinding: any
+  private frameCache: { [prefix: string]: Texture[] } = {}
 
   /**
    * Creates an instance of Renderer.
@@ -277,6 +278,7 @@ export default class Renderer extends ParticleContainer {
    */
   setTextures(textures: string[]) {
     this.textures = textures
+    this.frameCache = {}
     this.updateTexture()
   }
 
@@ -367,6 +369,10 @@ export default class Renderer extends ParticleContainer {
   }
 
   private createFrameAnimationByName(prefix: string, imageFileExtension: string = 'png'): Texture[] {
+    if (this.frameCache[prefix]) {
+      return this.frameCache[prefix]
+    }
+
     const zeroPad = this.zeroPad
     const textures: Texture[] = []
     let frame: string = ''
@@ -414,6 +420,7 @@ export default class Renderer extends ParticleContainer {
         texture = null
       }
     } while (texture)
+    this.frameCache[prefix] = textures
     return textures
   }
 

--- a/src/lib/pixi/TestRenderer.ts
+++ b/src/lib/pixi/TestRenderer.ts
@@ -33,6 +33,7 @@ export default class TestRenderer extends Container {
   private _model: Model = new Model()
   private _ticker: Ticker | undefined
   private _visibilitychangeBinding: any
+  private frameCache: { [prefix: string]: Texture[] } = {}
 
   /**
    * Creates an instance of Renderer.
@@ -265,6 +266,7 @@ export default class TestRenderer extends Container {
    */
   setTextures(textures: string[]) {
     this.textures = textures
+    this.frameCache = {}
     this.updateTexture()
   }
 
@@ -355,6 +357,10 @@ export default class TestRenderer extends Container {
   }
 
   private createFrameAnimationByName(prefix: string, imageFileExtension: string = 'png'): Texture[] {
+    if (this.frameCache[prefix]) {
+      return this.frameCache[prefix]
+    }
+
     const zeroPad = this.zeroPad
     const textures: Texture[] = []
     let frame: string = ''
@@ -402,6 +408,7 @@ export default class TestRenderer extends Container {
         texture = null
       }
     } while (texture)
+    this.frameCache[prefix] = textures
     return textures
   }
 

--- a/src/lib/util/Color.ts
+++ b/src/lib/util/Color.ts
@@ -20,12 +20,18 @@ export default class Color {
   private _g: number
   private _b: number
   private _alpha: number
+  private _hex: number = 0
+
+  private updateHex() {
+    this._hex = (this._r << 16) | (this._g << 8) | this._b
+  }
 
   constructor(r?: number, g?: number, b?: number, alpha?: number) {
     this.r = r || 0
     this.g = g || 0
     this.b = b || 0
     this.alpha = alpha || 1
+    this.updateHex()
   }
 
   /**
@@ -47,6 +53,7 @@ export default class Color {
   set r(value: number) {
     const newValue = value === undefined ? 0 : value
     this._r = newValue
+    this.updateHex()
   }
 
   /**
@@ -68,6 +75,7 @@ export default class Color {
   set g(value: number) {
     const newValue = value === undefined ? 0 : value
     this._g = newValue
+    this.updateHex()
   }
 
   /**
@@ -89,6 +97,7 @@ export default class Color {
   set b(value: number) {
     const newValue = value === undefined ? 0 : value
     this._b = newValue
+    this.updateHex()
   }
 
   /**
@@ -119,10 +128,7 @@ export default class Color {
    * @returns {number} The hex value of the Color object
    */
   get hex() {
-    let hex = this.r << 16
-    hex = hex | (this.g << 8)
-    hex = hex | this.b
-    return hex
+    return this._hex
   }
 
   /**
@@ -135,6 +141,7 @@ export default class Color {
     this.r = (value & 0xff0000) >> 16
     this.g = (value & 0xff00) >> 8
     this.b = value & 0xff
+    this._hex = value
   }
 
   /**
@@ -148,6 +155,7 @@ export default class Color {
     this.g = color.g
     this.b = color.b
     this.alpha = color.alpha
+    this.updateHex()
   }
 
   /**
@@ -161,6 +169,7 @@ export default class Color {
     this.g = data._g
     this.b = data._b
     this.alpha = data._alpha
+    this.updateHex()
   }
 
   /**
@@ -174,6 +183,7 @@ export default class Color {
     this.g += color.g
     this.b += color.b
     this.alpha += color.alpha
+    this.updateHex()
   }
 
   /**
@@ -190,6 +200,7 @@ export default class Color {
     this.g = g || 0
     this.b = b || 0
     this.alpha = alpha
+    this.updateHex()
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce camera updates in `EmitterBehaviours.apply`
- make `Emitter.update` synchronous
- loop directly when updating particles
- cache textures for frame animations
- cache computed color hex values
- reduce allocations in sound reactive behaviour
- avoid sqrt when force field distance outside radius
- add simple benchmarks for optimizations

## Testing
- `npm run lint` *(fails: tslint not found)*
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbe4384f48333aef7ec5c1fd7f759